### PR TITLE
Added functionality for public announcements

### DIFF
--- a/app/Http/Controllers/SettingController.php
+++ b/app/Http/Controllers/SettingController.php
@@ -38,12 +38,21 @@ class SettingController extends Controller
         $this->verifyAdmin();
 
         // Validate
-        $this->validate($request, [
-            'value' => 'required|numeric'
-        ]);
+        // we cannot require this field anymore, since the public announcement can be emptied...
+//        $this->validate($request, [
+//            'value' => 'required'
+//        ]);
+
+        // Find the setting
+        $setting = Setting::findOrFail($id);
+
+        // Manual validation
+        // If it is not a public announcement, it must be numeric
+        if($id != 'public_announcement'  && !is_numeric($request->value)) {
+            return back()->withErrors(['value' => "The value of " . $setting->display_name . " must be numeric"]);
+        }
 
         // Update the setting
-        $setting = Setting::findOrFail($id);
         $setting->value = $request->value;
 
         $setting->save();

--- a/database/seeds/SettingSeeder.php
+++ b/database/seeds/SettingSeeder.php
@@ -59,6 +59,13 @@ class SettingSeeder extends Seeder
             'value' => '0.20'
         ]);
 
+        // Public announcement
+        Setting::insert([
+            'key' => 'public_announcement',
+            'display_name' => 'Public Announcement',
+            'description' => 'Public announcement displayed on the main page of the website.',
+            'value' => ''
+        ]);
 
     }
 }

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -3,8 +3,18 @@
 @section('content')
     <div class="container section">
         <h1 class="display-4 mb-2">
-            Hello! {{ Auth::user()->fullName() }}
+            Hello {{ Auth::user()->fullName() }}!
         </h1>
+        @if(App\Setting::find('public_announcement')->value != '')
+            <div class="alert alert-warning" role="alert">
+                <h2>
+                    Public Announcement:
+                </h2>
+                <p>
+                    {{App\Setting::find('public_announcement')->value}}
+                </p>
+            </div>
+        @endif
         <div class="card mb-2">
             <div class="card-block p-1" style="background-color: #f3f3f3;">
                 <form action="" class="form-inline">

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -15,6 +15,15 @@
                         <p><strong>Success!</strong> {{ Session::get('success') }}</p>
                     </div>
                 @endif
+
+                @if(count($errors)> 0)
+                    @foreach($errors->all() as $error)
+                        <div class="alert alert-danger">
+                            {{ $error }}
+                        </div>
+                    @endforeach
+                @endif
+
                 @foreach($settings as $setting)
                     <div class="media">
                         <div class="media-body">
@@ -25,7 +34,7 @@
                                 {{ method_field('patch') }}
                                 <div class="form-group">
                                     <div class="input-group">
-                                        <input type="text" class="form-control" name="value" value="{{ $setting->value }}" required>
+                                        <input type="text" class="form-control" name="value" value="{{ $setting->value }}" >
                                         <span class="input-group-btn">
                                             <button class="btn btn-warning" type="submit">Update!</button>
                                         </span>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -6,6 +6,16 @@
             <div class="row">
                 <div class="col-md-8">
                     <h1>Drive more. Together</h1>
+                    @if(App\Setting::find('public_announcement')->value != '')
+                        <div class="alert alert-warning" role="alert">
+                            <h2>
+                                Public Announcement:
+                            </h2>
+                            <p>
+                                {{App\Setting::find('public_announcement')->value}}
+                            </p>
+                        </div>
+                    @endif
                     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet, commodi debitis doloribus eligendi excepturi explicabo id inventore iure maiores modi necessitatibus obcaecati odio quasi quibusdam quis, rem tempora vel voluptates!</p>
                 </div>
                 <div class="col-md-4">


### PR DESCRIPTION
Added functionality for public announcements. The requirements were that those announcement can be visible for any visitors on the website (the visitor does not have to be logged in). I basically added this announcement field in the `home `and `welcome `pages.

- Public announcement is now part of the `settings `table in the database (added to the settings seed).
- Since the announcement can be cleared, but not other values, I changed the validation so that if the controller is trying to update a field that isn't the public announcement, the value must be numeric, otherwise it can be anything. 

Please let me know if this is ok, and feel free to change the UI I chose for the announcement. I chose the `alert-warning`